### PR TITLE
feat: automatic per-model context limits (1M default, 200K denylist)

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,8 +1,35 @@
+# VCS
 **/.git
 **/.svn
 **/.hg
 **/CVS
+
+# OS artifacts
 **/.DS_Store
 **/Thumbs.db
+
+# Dependencies
 **/node_modules
-**/*.vsix
+
+# Build artifacts
+*.vsix
+
+# TypeScript source (compiled to out/)
+src/
+
+# Build configuration
+tsconfig.json
+
+# Dev tooling configs
+.gitignore
+.vscodeignore
+.github/
+.vscode/
+.claude/
+
+# Internal documentation (README.md and CHANGELOG.md are for the marketplace)
+CLAUDE.md
+
+# Compiled test files
+**/*.test.js
+**/*.test.js.map

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -29,7 +29,24 @@ tsconfig.json
 
 # Internal documentation (README.md and CHANGELOG.md are for the marketplace)
 CLAUDE.md
+DEV-README.md
+INTERNAL-DEV-NOTES.md
+whats-next.md
+
+# Generated knowledge graph
+graphify-out/
 
 # Compiled test files
 **/*.test.js
 **/*.test.js.map
+
+# Dev-only compiled scripts (not part of the runtime extension)
+out/debug.js
+out/debug.js.map
+out/diagnose_sessions.js
+out/diagnose_sessions.js.map
+out/verify_real_data.js
+out/verify_real_data.js.map
+
+# Source maps (not needed in the published package)
+out/**/*.js.map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,15 @@ All notable changes to the Claude Context Bar extension will be documented in th
 ## [1.5.0] - 2026-07-06
 
 ### Changed
-☼ **Three-tier context limit resolution**: Replaced the old ad-hoc heuristic with a priority chain
-  ☼ **Tier 1 — User configuration**: New `modelContextLimits` setting (object, per-model token limits). Exact Model ID match. Highest priority, no model is force-capped.
-  ☼ **Tier 2 — Auto-detection**: A Model ID containing `claude-sonnet-5` resolves to 1,000,000 tokens. Sonnet 5 is the only model confirmed to have universal 1M access across all subscription tiers.
-  ☼ **Tier 3 — Global fallback**: `contextLimit` setting (default 200,000) as the bottom-layer fallback.
-☼ Removed the old `sonnet` + `1m` substring heuristic in favor of precise `claude-sonnet-5` detection.
-☼ Extracted the resolution logic into a pure `getContextLimitForModel` function.
+☼ **Context limit auto-detection rewritten** to default to 1M and list the 200K exceptions, instead of the old `sonnet` + `1m` heuristic that missed nearly every model.
+  ☼ **1M by default**: every current Claude model (Opus 4.6+, Sonnet 4.6+, Sonnet 5, Fable 5, and anything newer) resolves to 1,000,000 tokens. New models are detected automatically with no extension update.
+  ☼ **200K exceptions**: Haiku (all versions) and legacy generations (Claude 3.x, Sonnet 4.5 and earlier, Opus 4.5 and earlier) resolve to 200,000.
+  ☼ **Fallback**: unknown or non-Claude Model IDs use the `contextLimit` setting (default 200,000).
+☼ Extracted the resolution into a pure `getContextLimitForModel` function.
 
 ### Added
-☼ `claudeContextBar.modelContextLimits` setting: per-model context limit overrides (object, default `{}`).
-☼ Unit test suite (22 tests) covering all three tiers, run with Node's built-in test runner (`npm test`, no extra dependencies).
+☼ `claudeContextBar.modelContextLimits` setting: per-model overrides (object, default `{}`). Exact Model ID match, highest priority. No model is force-capped.
+☼ Unit test suite (25 tests) run with Node's built-in test runner (`npm test`, no extra dependencies).
 
 ## [1.4.1] - 2025-12-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the Claude Context Bar extension will be documented in this file.
 
+## [1.5.0] - 2026-07-06
+
+### Changed
+☼ **Three-tier context limit resolution**: Replaced the old ad-hoc heuristic with a priority chain
+  ☼ **Tier 1 — User configuration**: New `modelContextLimits` setting (object, per-model token limits). Exact Model ID match. Highest priority, no model is force-capped.
+  ☼ **Tier 2 — Auto-detection**: A Model ID containing `claude-sonnet-5` resolves to 1,000,000 tokens. Sonnet 5 is the only model confirmed to have universal 1M access across all subscription tiers.
+  ☼ **Tier 3 — Global fallback**: `contextLimit` setting (default 200,000) as the bottom-layer fallback.
+☼ Removed the old `sonnet` + `1m` substring heuristic in favor of precise `claude-sonnet-5` detection.
+☼ Extracted the resolution logic into a pure `getContextLimitForModel` function.
+
+### Added
+☼ `claudeContextBar.modelContextLimits` setting: per-model context limit overrides (object, default `{}`).
+☼ Unit test suite (22 tests) covering all three tiers, run with Node's built-in test runner (`npm test`, no extra dependencies).
+
 ## [1.4.1] - 2025-12-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ Sessions inactive for more than 3 minutes (configurable via `idleTimeout`) are a
 
 ## License
 
-MIT © 2025 [Ed Zisk](https://github.com/ezoosk)
+MIT © 2025 [Ed Zisk](https://github.com/edenaion)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 🎨 **Auto Color Mode** — Each project automatically gets a unique pastel color for easy identification
 
-🔍 **Smart Context Detection** — Three-tier context limit resolution automatically detects your model's context window
+🔍 **Smart Context Detection** — Automatically sizes the context window per model (1M for current models, 200K for Haiku and legacy), with per-model overrides
 
 ⚠️ **Color-Coded Warnings**:
 - Normal: Under 50% usage
@@ -57,8 +57,8 @@
 | `claudeContextBar.showEmoji` | `true` | Show emoji icons based on project name keywords |
 | `claudeContextBar.autoColor` | `true` | Automatically assign unique pastel colors to each project |
 | `claudeContextBar.baseColor` | `White` | Base color when Auto Color is off (subtle variations per project) |
-| `claudeContextBar.contextLimit` | `200000` | Global fallback context limit (used when no per-model override or auto-detection matches) |
-| `claudeContextBar.modelContextLimits` | `{}` | Per-model context limits: Model ID → token limit (e.g., `{"claude-opus-4-8": 1000000}`). Exact match, highest priority |
+| `claudeContextBar.contextLimit` | `200000` | Fallback for unknown or non-Claude model IDs (Claude models are auto-detected) |
+| `claudeContextBar.modelContextLimits` | `{}` | Per-model overrides: Model ID → token limit (e.g., `{"claude-haiku-4-5": 500000}`). Exact match, highest priority |
 | `claudeContextBar.warningThreshold` | `50` | Percentage for yellow warning |
 | `claudeContextBar.dangerThreshold` | `75` | Percentage for red danger |
 | `claudeContextBar.refreshInterval` | `30` | Refresh interval in seconds |
@@ -68,13 +68,14 @@
 
 ## How It Works
 
-The extension reads Claude Code's session files from `~/.claude/projects/` and calculates token usage from the JSONL logs. It resolves the context limit using a three-tier priority chain:
+The extension reads Claude Code's session files from `~/.claude/projects/` and calculates token usage from the JSONL logs. It resolves the context limit per model using this priority chain:
 
-1. **User configuration** — the `modelContextLimits` setting (exact Model ID match). Highest priority, overrides everything below.
-2. **Auto-detection** — a Model ID containing `claude-sonnet-5` resolves to 1,000,000 tokens. Sonnet 5 is the only model currently confirmed to have universal 1M access across all subscription tiers.
-3. **Global fallback** — the `contextLimit` setting (default 200,000 tokens), used for all other models.
+1. **User override** — the `modelContextLimits` setting (exact Model ID match). Highest priority, overrides everything below.
+2. **200K models** — Haiku and legacy generations (Claude 3.x, Sonnet 4.5 and earlier, Opus 4.5 and earlier) resolve to 200,000 tokens.
+3. **1M default** — every other current Claude model resolves to 1,000,000 tokens (Opus 4.6+, Sonnet 4.6+, Sonnet 5, Fable 5, and anything newer).
+4. **Fallback** — unknown or non-Claude Model IDs use the `contextLimit` setting (default 200,000).
 
-Claude session files record only the Model ID, with no context-window field, and a model's usable limit depends on your subscription tier and usage credits, which are not detectable from the file. So auto-detection stays conservative. For any 1M model that is not auto-detected (for example Opus 4.8 or Fable 5 when you have 1M access), set an explicit value in `modelContextLimits` and it will always be respected. No model is force-capped.
+Claude session files record only the Model ID, with no context-window field, so the limit is inferred from the ID. The default is 1M because current frontier models all ship with a 1M window, which means new models resolve correctly with no update needed. Haiku and legacy models are the 200K exceptions. If any model is ever mis-sized (for example, your plan caps a model lower than its API window), pin an exact value in `modelContextLimits` and it always wins.
 
 Sessions inactive for more than 3 minutes (configurable via `idleTimeout`) are automatically hidden. The extension also detects when sessions have been superseded by newer ones (e.g., after running `/clear` and opening a new tab), hiding ghost sessions immediately.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 🎨 **Auto Color Mode** — Each project automatically gets a unique pastel color for easy identification
 
-🔍 **Smart Context Detection** — Automatically detects your model (Sonnet 4.5 1M vs others) and adjusts the context limit accordingly
+🔍 **Smart Context Detection** — Three-tier context limit resolution automatically detects your model's context window
 
 ⚠️ **Color-Coded Warnings**:
 - Normal: Under 50% usage
@@ -57,7 +57,8 @@
 | `claudeContextBar.showEmoji` | `true` | Show emoji icons based on project name keywords |
 | `claudeContextBar.autoColor` | `true` | Automatically assign unique pastel colors to each project |
 | `claudeContextBar.baseColor` | `White` | Base color when Auto Color is off (subtle variations per project) |
-| `claudeContextBar.contextLimit` | `200000` | Fallback context limit (auto-detected for most models) |
+| `claudeContextBar.contextLimit` | `200000` | Global fallback context limit (used when no per-model override or auto-detection matches) |
+| `claudeContextBar.modelContextLimits` | `{}` | Per-model context limits: Model ID → token limit (e.g., `{"claude-opus-4-8": 1000000}`). Exact match, highest priority |
 | `claudeContextBar.warningThreshold` | `50` | Percentage for yellow warning |
 | `claudeContextBar.dangerThreshold` | `75` | Percentage for red danger |
 | `claudeContextBar.refreshInterval` | `30` | Refresh interval in seconds |
@@ -67,10 +68,13 @@
 
 ## How It Works
 
-The extension reads Claude Code's session files from `~/.claude/projects/` and calculates token usage from the JSONL logs. It automatically detects which model you're using and adjusts the context limit:
+The extension reads Claude Code's session files from `~/.claude/projects/` and calculates token usage from the JSONL logs. It resolves the context limit using a three-tier priority chain:
 
-- **Claude Sonnet 4.5 1M**: 1,000,000 tokens
-- **All other models** (Sonnet 4.5, Opus 4.5, Haiku): 200,000 tokens
+1. **User configuration** — the `modelContextLimits` setting (exact Model ID match). Highest priority, overrides everything below.
+2. **Auto-detection** — a Model ID containing `claude-sonnet-5` resolves to 1,000,000 tokens. Sonnet 5 is the only model currently confirmed to have universal 1M access across all subscription tiers.
+3. **Global fallback** — the `contextLimit` setting (default 200,000 tokens), used for all other models.
+
+Claude session files record only the Model ID, with no context-window field, and a model's usable limit depends on your subscription tier and usage credits, which are not detectable from the file. So auto-detection stays conservative. For any 1M model that is not auto-detected (for example Opus 4.8 or Fable 5 when you have 1M access), set an explicit value in `modelContextLimits` and it will always be respected. No model is force-capped.
 
 Sessions inactive for more than 3 minutes (configurable via `idleTimeout`) are automatically hidden. The extension also detects when sessions have been superseded by newer ones (e.g., after running `/clear` and opening a new tab), hiding ghost sessions immediately.
 

--- a/package.json
+++ b/package.json
@@ -73,12 +73,12 @@
                 "claudeContextBar.contextLimit": {
                     "type": "number",
                     "default": 200000,
-                    "description": "Global fallback context window size in tokens. Used when no per-model override is configured and the model is not auto-detected as 1M-capable."
+                    "description": "Fallback context window size in tokens, used only for unknown or non-Claude model IDs. Current Claude models are auto-detected (1M by default, 200K for Haiku and legacy models)."
                 },
                 "claudeContextBar.modelContextLimits": {
                     "type": "object",
                     "default": {},
-                    "description": "Per-model context limits (Model ID → token limit). Exact match only, no glob or prefix matching. Example: {\"claude-opus-4-8\": 1000000}. Takes precedence over auto-detection and the global contextLimit fallback."
+                    "description": "Per-model context limit overrides (Model ID → token limit). Exact match only, no glob or prefix matching. Example: {\"claude-haiku-4-5\": 500000}. Highest priority: overrides auto-detection and the fallback for that exact model."
                 },
                 "claudeContextBar.warningThreshold": {
                     "type": "number",

--- a/package.json
+++ b/package.json
@@ -6,16 +6,16 @@
     "publisher": "ezoosk",
     "author": {
         "name": "Ed Zisk",
-        "url": "https://github.com/ezoosk"
+        "url": "https://github.com/edenaion"
     },
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ezoosk/claude-context-bar"
+        "url": "https://github.com/edenaion/claude-context-bar"
     },
-    "homepage": "https://github.com/ezoosk/claude-context-bar#readme",
+    "homepage": "https://github.com/edenaion/claude-context-bar#readme",
     "bugs": {
-        "url": "https://github.com/ezoosk/claude-context-bar/issues"
+        "url": "https://github.com/edenaion/claude-context-bar/issues"
     },
     "icon": "images/icon.png",
     "galleryBanner": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "claude-context-bar",
     "displayName": "Claude Context Bar",
     "description": "Real-time context window usage monitor for Claude Code sessions. See token counts in your status bar with color-coded warnings.",
-    "version": "1.4.1",
+    "version": "1.5.0",
     "publisher": "ezoosk",
     "author": {
         "name": "Ed Zisk",
@@ -73,7 +73,12 @@
                 "claudeContextBar.contextLimit": {
                     "type": "number",
                     "default": 200000,
-                    "description": "Maximum context window size in tokens"
+                    "description": "Global fallback context window size in tokens. Used when no per-model override is configured and the model is not auto-detected as 1M-capable."
+                },
+                "claudeContextBar.modelContextLimits": {
+                    "type": "object",
+                    "default": {},
+                    "description": "Per-model context limits (Model ID → token limit). Exact match only, no glob or prefix matching. Example: {\"claude-opus-4-8\": 1000000}. Takes precedence over auto-detection and the global contextLimit fallback."
                 },
                 "claudeContextBar.warningThreshold": {
                     "type": "number",
@@ -115,6 +120,7 @@
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
         "lint": "eslint src --ext ts",
+        "test": "tsc -p ./ && node --test out/*.test.js",
         "package": "vsce package",
         "publish": "vsce publish"
     },

--- a/src/contextLimit.test.ts
+++ b/src/contextLimit.test.ts
@@ -12,103 +12,112 @@ describe('getContextLimitForModel', () => {
         assert.equal(getContextLimitForModel('claude-opus-4-8', 200_000, dict), 500_000);
     });
 
-    it('user config overrides Sonnet 5 auto-detection', () => {
-        const dict = { 'claude-sonnet-5': 300_000 };
-        assert.equal(getContextLimitForModel('claude-sonnet-5', 200_000, dict), 300_000);
+    it('user override wins over the 1M default', () => {
+        const dict = { 'claude-opus-4-8': 300_000 };
+        assert.equal(getContextLimitForModel('claude-opus-4-8', 200_000, dict), 300_000);
     });
 
-    it('user config overrides fallback even for hard-capped models like Haiku 4.5', () => {
+    it('user override can raise a 200K model (e.g. Haiku) to 1M', () => {
         const dict = { 'claude-haiku-4-5': 1_000_000 };
         assert.equal(getContextLimitForModel('claude-haiku-4-5', 200_000, dict), 1_000_000);
     });
 
-    it('exact model ID match only  no partial or prefix matching', () => {
-        const dict = { 'claude-sonnet': 500_000 };
-        // "claude-sonnet-5" does not exactly match "claude-sonnet", so tier 1
-        // misses and tier 2 auto-detects it as 1M.
-        assert.equal(getContextLimitForModel('claude-sonnet-5', 200_000, dict), 1_000_000);
+    it('override is exact Model ID match only', () => {
+        const dict = { 'claude-opus': 500_000 };
+        // "claude-opus-4-8" does not exactly match "claude-opus", so it falls
+        // through to the 1M default.
+        assert.equal(getContextLimitForModel('claude-opus-4-8', 200_000, dict), 1_000_000);
     });
 
-    it('user config entry for a different model does not affect other models', () => {
-        const dict = { 'claude-opus-4-8': 500_000 };
-        assert.equal(getContextLimitForModel('claude-haiku-4-5', 200_000, dict), 200_000);
+    // Tier 2: known 200K exceptions (Haiku + legacy)
+
+    it('Haiku 4.5 resolves to 200K', () => {
+        assert.equal(getContextLimitForModel('claude-haiku-4-5-20251001', 200_000, emptyDict), 200_000);
     });
 
-    // Tier 2: auto-detection  Sonnet 5 -> 1,000,000
-
-    it('returns 1M for claude-sonnet-5 with no user config', () => {
-        assert.equal(getContextLimitForModel('claude-sonnet-5', 200_000, emptyDict), 1_000_000);
+    it('any Haiku resolves to 200K (future-proof pattern)', () => {
+        assert.equal(getContextLimitForModel('claude-haiku-5', 200_000, emptyDict), 200_000);
     });
 
-    it('returns 1M for claude-sonnet-5 regardless of case', () => {
-        assert.equal(getContextLimitForModel('CLAUDE-SONNET-5', 200_000, emptyDict), 1_000_000);
-    });
-
-    it('returns 1M for mixed-case Claude-Sonnet-5', () => {
-        assert.equal(getContextLimitForModel('Claude-Sonnet-5', 200_000, emptyDict), 1_000_000);
-    });
-
-    it('returns 1M for claude-sonnet-5 with date suffix', () => {
-        assert.equal(getContextLimitForModel('claude-sonnet-5-20251001', 200_000, emptyDict), 1_000_000);
-    });
-
-    it('claude-sonnet-5 substring match does not collide with claude-sonnet-4-5', () => {
+    it('Sonnet 4.5 resolves to 200K', () => {
         assert.equal(getContextLimitForModel('claude-sonnet-4-5', 200_000, emptyDict), 200_000);
     });
 
-    it('claude-sonnet-5 substring match does not collide with claude-sonnet-4-6', () => {
-        assert.equal(getContextLimitForModel('claude-sonnet-4-6', 200_000, emptyDict), 200_000);
+    it('Sonnet 4.5 dated ID resolves to 200K', () => {
+        assert.equal(getContextLimitForModel('claude-sonnet-4-5-20250929', 200_000, emptyDict), 200_000);
     });
 
-    // Tier 3: global fallback  userLimit
-
-    it('returns userLimit when model is not in dict and is not Sonnet 5', () => {
-        assert.equal(getContextLimitForModel('claude-opus-4-8', 200_000, emptyDict), 200_000);
+    it('Opus 4.5 resolves to 200K', () => {
+        assert.equal(getContextLimitForModel('claude-opus-4-5', 200_000, emptyDict), 200_000);
     });
 
-    it('returns custom userLimit for unknown model', () => {
-        assert.equal(getContextLimitForModel('claude-opus-4-8', 500_000, emptyDict), 500_000);
+    it('Opus 4.1 resolves to 200K', () => {
+        assert.equal(getContextLimitForModel('claude-opus-4-1-20250805', 200_000, emptyDict), 200_000);
     });
 
-    it('returns userLimit for claude-haiku-4-5', () => {
-        assert.equal(getContextLimitForModel('claude-haiku-4-5', 200_000, emptyDict), 200_000);
+    it('Opus 4.0 dated ID resolves to 200K', () => {
+        assert.equal(getContextLimitForModel('claude-opus-4-20250514', 200_000, emptyDict), 200_000);
     });
 
-    it('returns userLimit for empty model string', () => {
-        assert.equal(getContextLimitForModel('', 200_000, emptyDict), 200_000);
+    it('Claude 3.x family resolves to 200K', () => {
+        assert.equal(getContextLimitForModel('claude-3-5-sonnet-20241022', 200_000, emptyDict), 200_000);
     });
 
-    it('returns userLimit for whitespace-only model string', () => {
-        assert.equal(getContextLimitForModel('   ', 200_000, emptyDict), 200_000);
+    // Tier 3: default 1M for current frontier models
+
+    it('Opus 4.8 resolves to 1M by default', () => {
+        assert.equal(getContextLimitForModel('claude-opus-4-8', 200_000, emptyDict), 1_000_000);
     });
 
-    it('returns userLimit for future/unknown model IDs', () => {
-        assert.equal(getContextLimitForModel('claude-future-model-99', 200_000, emptyDict), 200_000);
+    it('Opus 4.6 resolves to 1M', () => {
+        assert.equal(getContextLimitForModel('claude-opus-4-6', 200_000, emptyDict), 1_000_000);
     });
 
-    // Edge cases
-
-    it('user config for empty string model overrides fallback', () => {
-        const dict = { '': 999_000 };
-        assert.equal(getContextLimitForModel('', 200_000, dict), 999_000);
+    it('Sonnet 4.6 resolves to 1M', () => {
+        assert.equal(getContextLimitForModel('claude-sonnet-4-6', 200_000, emptyDict), 1_000_000);
     });
 
-    it('removing a model from dict falls through to auto-detection', () => {
-        // Sonnet 5 without user config -> auto-detected as 1M.
+    it('Sonnet 5 resolves to 1M', () => {
         assert.equal(getContextLimitForModel('claude-sonnet-5', 200_000, emptyDict), 1_000_000);
     });
 
-    it('non-Sonnet-5 model removed from dict falls through to fallback', () => {
-        assert.equal(getContextLimitForModel('claude-haiku-4-5', 200_000, emptyDict), 200_000);
+    it('Fable 5 resolves to 1M', () => {
+        assert.equal(getContextLimitForModel('claude-fable-5', 200_000, emptyDict), 1_000_000);
     });
 
-    it('old sonnet+1m heuristic no longer applies  claude-sonnet-4-5-1m falls back', () => {
-        // The old heuristic (sonnet + 1m) is removed. Non-universal models with
-        // "1m" in the name no longer auto-detect as 1M.
-        assert.equal(getContextLimitForModel('claude-sonnet-4-5-1m', 200_000, emptyDict), 200_000);
+    it('unknown future Claude model defaults to 1M (no code change needed)', () => {
+        assert.equal(getContextLimitForModel('claude-opus-9-99', 200_000, emptyDict), 1_000_000);
     });
 
-    it('default contextLimit of 200000 is used when no config overrides', () => {
-        assert.equal(getContextLimitForModel('claude-haiku-4-5', 200_000, emptyDict), 200_000);
+    it('resolves regardless of case', () => {
+        assert.equal(getContextLimitForModel('CLAUDE-OPUS-4-8', 200_000, emptyDict), 1_000_000);
+        assert.equal(getContextLimitForModel('Claude-Haiku-4-5', 200_000, emptyDict), 200_000);
+    });
+
+    // Tier 4: unknown / non-Claude IDs fall back to userLimit
+
+    it('empty model string uses the fallback', () => {
+        assert.equal(getContextLimitForModel('', 200_000, emptyDict), 200_000);
+    });
+
+    it('whitespace-only model string uses the fallback', () => {
+        assert.equal(getContextLimitForModel('   ', 200_000, emptyDict), 200_000);
+    });
+
+    it('synthetic model marker uses the fallback', () => {
+        assert.equal(getContextLimitForModel('<synthetic>', 200_000, emptyDict), 200_000);
+    });
+
+    it('non-Claude model uses the fallback', () => {
+        assert.equal(getContextLimitForModel('gpt-5', 200_000, emptyDict), 200_000);
+    });
+
+    it('custom fallback is honored for unknown models', () => {
+        assert.equal(getContextLimitForModel('<synthetic>', 500_000, emptyDict), 500_000);
+    });
+
+    it('override for empty string beats the fallback', () => {
+        const dict = { '': 999_000 };
+        assert.equal(getContextLimitForModel('', 200_000, dict), 999_000);
     });
 });

--- a/src/contextLimit.test.ts
+++ b/src/contextLimit.test.ts
@@ -1,0 +1,114 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { getContextLimitForModel } from './contextLimit';
+
+describe('getContextLimitForModel', () => {
+    const emptyDict: Record<string, number> = {};
+
+    // Tier 1: user configuration (modelContextLimits)  highest priority
+
+    it('returns configured value when model is in modelContextLimits', () => {
+        const dict = { 'claude-opus-4-8': 500_000 };
+        assert.equal(getContextLimitForModel('claude-opus-4-8', 200_000, dict), 500_000);
+    });
+
+    it('user config overrides Sonnet 5 auto-detection', () => {
+        const dict = { 'claude-sonnet-5': 300_000 };
+        assert.equal(getContextLimitForModel('claude-sonnet-5', 200_000, dict), 300_000);
+    });
+
+    it('user config overrides fallback even for hard-capped models like Haiku 4.5', () => {
+        const dict = { 'claude-haiku-4-5': 1_000_000 };
+        assert.equal(getContextLimitForModel('claude-haiku-4-5', 200_000, dict), 1_000_000);
+    });
+
+    it('exact model ID match only  no partial or prefix matching', () => {
+        const dict = { 'claude-sonnet': 500_000 };
+        // "claude-sonnet-5" does not exactly match "claude-sonnet", so tier 1
+        // misses and tier 2 auto-detects it as 1M.
+        assert.equal(getContextLimitForModel('claude-sonnet-5', 200_000, dict), 1_000_000);
+    });
+
+    it('user config entry for a different model does not affect other models', () => {
+        const dict = { 'claude-opus-4-8': 500_000 };
+        assert.equal(getContextLimitForModel('claude-haiku-4-5', 200_000, dict), 200_000);
+    });
+
+    // Tier 2: auto-detection  Sonnet 5 -> 1,000,000
+
+    it('returns 1M for claude-sonnet-5 with no user config', () => {
+        assert.equal(getContextLimitForModel('claude-sonnet-5', 200_000, emptyDict), 1_000_000);
+    });
+
+    it('returns 1M for claude-sonnet-5 regardless of case', () => {
+        assert.equal(getContextLimitForModel('CLAUDE-SONNET-5', 200_000, emptyDict), 1_000_000);
+    });
+
+    it('returns 1M for mixed-case Claude-Sonnet-5', () => {
+        assert.equal(getContextLimitForModel('Claude-Sonnet-5', 200_000, emptyDict), 1_000_000);
+    });
+
+    it('returns 1M for claude-sonnet-5 with date suffix', () => {
+        assert.equal(getContextLimitForModel('claude-sonnet-5-20251001', 200_000, emptyDict), 1_000_000);
+    });
+
+    it('claude-sonnet-5 substring match does not collide with claude-sonnet-4-5', () => {
+        assert.equal(getContextLimitForModel('claude-sonnet-4-5', 200_000, emptyDict), 200_000);
+    });
+
+    it('claude-sonnet-5 substring match does not collide with claude-sonnet-4-6', () => {
+        assert.equal(getContextLimitForModel('claude-sonnet-4-6', 200_000, emptyDict), 200_000);
+    });
+
+    // Tier 3: global fallback  userLimit
+
+    it('returns userLimit when model is not in dict and is not Sonnet 5', () => {
+        assert.equal(getContextLimitForModel('claude-opus-4-8', 200_000, emptyDict), 200_000);
+    });
+
+    it('returns custom userLimit for unknown model', () => {
+        assert.equal(getContextLimitForModel('claude-opus-4-8', 500_000, emptyDict), 500_000);
+    });
+
+    it('returns userLimit for claude-haiku-4-5', () => {
+        assert.equal(getContextLimitForModel('claude-haiku-4-5', 200_000, emptyDict), 200_000);
+    });
+
+    it('returns userLimit for empty model string', () => {
+        assert.equal(getContextLimitForModel('', 200_000, emptyDict), 200_000);
+    });
+
+    it('returns userLimit for whitespace-only model string', () => {
+        assert.equal(getContextLimitForModel('   ', 200_000, emptyDict), 200_000);
+    });
+
+    it('returns userLimit for future/unknown model IDs', () => {
+        assert.equal(getContextLimitForModel('claude-future-model-99', 200_000, emptyDict), 200_000);
+    });
+
+    // Edge cases
+
+    it('user config for empty string model overrides fallback', () => {
+        const dict = { '': 999_000 };
+        assert.equal(getContextLimitForModel('', 200_000, dict), 999_000);
+    });
+
+    it('removing a model from dict falls through to auto-detection', () => {
+        // Sonnet 5 without user config -> auto-detected as 1M.
+        assert.equal(getContextLimitForModel('claude-sonnet-5', 200_000, emptyDict), 1_000_000);
+    });
+
+    it('non-Sonnet-5 model removed from dict falls through to fallback', () => {
+        assert.equal(getContextLimitForModel('claude-haiku-4-5', 200_000, emptyDict), 200_000);
+    });
+
+    it('old sonnet+1m heuristic no longer applies  claude-sonnet-4-5-1m falls back', () => {
+        // The old heuristic (sonnet + 1m) is removed. Non-universal models with
+        // "1m" in the name no longer auto-detect as 1M.
+        assert.equal(getContextLimitForModel('claude-sonnet-4-5-1m', 200_000, emptyDict), 200_000);
+    });
+
+    it('default contextLimit of 200000 is used when no config overrides', () => {
+        assert.equal(getContextLimitForModel('claude-haiku-4-5', 200_000, emptyDict), 200_000);
+    });
+});

--- a/src/contextLimit.ts
+++ b/src/contextLimit.ts
@@ -1,23 +1,24 @@
 /**
  * Pure function: determine the context window limit for a given model.
  *
- * Three-tier priority chain (highest first):
+ * Priority chain (highest first):
  * 1. User configuration  exact Model ID match in `modelContextLimits`
- * 2. Auto-detection      model ID matches a known universal-1M model
- * 3. Global fallback     `userLimit` (the VS Code `contextLimit` setting)
+ * 2. Known 200K exceptions  Haiku and legacy models (the denylist below)
+ * 3. Default  1,000,000 for any other current Claude model
+ * 4. Unknown / non-Claude IDs  `userLimit` (the global `contextLimit` setting)
  *
- * Why so conservative on tier 2: Claude session JSONL records only the model
- * ID string. It carries no context-window field, and a model's *effective*
- * limit depends on subscription tier and usage-credits state, neither of which
- * is detectable from the file. So we auto-promote a model to 1M only when it is
- * confirmed to have 1M universally, across every tier, with no extra steps.
- * Everything else stays at the fallback until the user sets an explicit
- * override. The override always wins, so a user on any 1M model (or a pinned
- * extension version) can always correct the value themselves.
+ * Why the default is 1M, not 200K: Claude session JSONL records only the Model
+ * ID. It has no context-window field, so the limit has to be inferred from the
+ * ID. Every current frontier model ships with a 1M window by default (Opus 4.6
+ * and up, Sonnet 4.6 and up, Sonnet 5, Fable 5, Mythos 5). The only 200K models
+ * are the small Haiku tier and retired legacy generations. Defaulting to 1M and
+ * listing the 200K exceptions means new models resolve correctly with no code
+ * change, since new models keep shipping at 1M. If a model is ever mis-sized,
+ * the user override in tier 1 always wins.
  *
- * @param model                Model ID string (e.g. "claude-sonnet-5-20251001")
- * @param userLimit            Fallback context limit from VS Code settings
- * @param modelContextLimits   Per-model context limits from user configuration
+ * @param model                Model ID string (e.g. "claude-opus-4-8")
+ * @param userLimit            Fallback for unknown / non-Claude IDs (VS Code `contextLimit`)
+ * @param modelContextLimits   Per-model overrides from user configuration
  * @returns                    Context window size in tokens
  */
 export function getContextLimitForModel(
@@ -30,26 +31,42 @@ export function getContextLimitForModel(
         return modelContextLimits[model];
     }
 
-    // Tier 2: auto-detect known universal-1M models (lowercase substring match).
-    const id = model.toLowerCase();
-    if (UNIVERSAL_1M_MODELS.some((m) => id.includes(m))) {
-        return 1_000_000;
+    const id = model.toLowerCase().trim();
+
+    // Tier 4 (guard): unknown or non-Claude IDs (e.g. "", "<synthetic>") use
+    // the configured fallback rather than the 1M default.
+    if (!id.startsWith('claude')) {
+        return userLimit;
     }
 
-    // Tier 3: global fallback.
-    return userLimit;
+    // Tier 2: known 200K models (Haiku + legacy). Lowercase substring match.
+    if (CONTEXT_200K_MODELS.some((m) => id.includes(m))) {
+        return CONTEXT_200K;
+    }
+
+    // Tier 3: default. Current Claude frontier models ship at 1M.
+    return CONTEXT_1M;
 }
 
+const CONTEXT_1M = 1_000_000;
+const CONTEXT_200K = 200_000;
+
 /**
- * Model IDs that get 1,000,000-token context universally  across every
- * subscription tier and credits state, with no extra steps required.
+ * Model IDs whose context window is 200K, the exceptions to the 1M default.
+ * Matched as lowercase substrings of the Model ID.
  *
- * Conservative by design. A model is added here only once confirmed to be
- * universal-1M. Models whose 1M depends on tier or usage credits (Opus 4.6+,
- * Sonnet 4.6+) are intentionally absent; users on those set an explicit
- * override in the `modelContextLimits` setting instead. Adding a model is one
- * line here, but prefer the user override for anything not truly universal.
+ * This list grows rarely: the `haiku` entry already covers the whole Haiku
+ * tier (current and future), and the legacy entries are frozen (old models do
+ * not change). New frontier models are 1M and need no entry here.
  */
-const UNIVERSAL_1M_MODELS: readonly string[] = [
-    'claude-sonnet-5',
+const CONTEXT_200K_MODELS: readonly string[] = [
+    'haiku',                 // all Haiku models (200K)
+    'claude-3',              // Claude 3.x family
+    'claude-opus-4-0',       // Opus 4.0
+    'claude-opus-4-1',       // Opus 4.1
+    'claude-opus-4-5',       // Opus 4.5
+    'claude-opus-4-2025',    // Opus 4.0 (dated ID)
+    'claude-sonnet-4-0',     // Sonnet 4.0
+    'claude-sonnet-4-5',     // Sonnet 4.5
+    'claude-sonnet-4-2025',  // Sonnet 4.0 (dated ID)
 ];

--- a/src/contextLimit.ts
+++ b/src/contextLimit.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure function: determine the context window limit for a given model.
+ *
+ * Three-tier priority chain (highest first):
+ * 1. User configuration  exact Model ID match in `modelContextLimits`
+ * 2. Auto-detection      model ID matches a known universal-1M model
+ * 3. Global fallback     `userLimit` (the VS Code `contextLimit` setting)
+ *
+ * Why so conservative on tier 2: Claude session JSONL records only the model
+ * ID string. It carries no context-window field, and a model's *effective*
+ * limit depends on subscription tier and usage-credits state, neither of which
+ * is detectable from the file. So we auto-promote a model to 1M only when it is
+ * confirmed to have 1M universally, across every tier, with no extra steps.
+ * Everything else stays at the fallback until the user sets an explicit
+ * override. The override always wins, so a user on any 1M model (or a pinned
+ * extension version) can always correct the value themselves.
+ *
+ * @param model                Model ID string (e.g. "claude-sonnet-5-20251001")
+ * @param userLimit            Fallback context limit from VS Code settings
+ * @param modelContextLimits   Per-model context limits from user configuration
+ * @returns                    Context window size in tokens
+ */
+export function getContextLimitForModel(
+    model: string,
+    userLimit: number,
+    modelContextLimits: Record<string, number>,
+): number {
+    // Tier 1: user override, exact Model ID match, highest priority.
+    if (model in modelContextLimits) {
+        return modelContextLimits[model];
+    }
+
+    // Tier 2: auto-detect known universal-1M models (lowercase substring match).
+    const id = model.toLowerCase();
+    if (UNIVERSAL_1M_MODELS.some((m) => id.includes(m))) {
+        return 1_000_000;
+    }
+
+    // Tier 3: global fallback.
+    return userLimit;
+}
+
+/**
+ * Model IDs that get 1,000,000-token context universally  across every
+ * subscription tier and credits state, with no extra steps required.
+ *
+ * Conservative by design. A model is added here only once confirmed to be
+ * universal-1M. Models whose 1M depends on tier or usage credits (Opus 4.6+,
+ * Sonnet 4.6+) are intentionally absent; users on those set an explicit
+ * override in the `modelContextLimits` setting instead. Adding a model is one
+ * line here, but prefer the user override for anything not truly universal.
+ */
+const UNIVERSAL_1M_MODELS: readonly string[] = [
+    'claude-sonnet-5',
+];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as readline from 'readline';
+import { getContextLimitForModel } from './contextLimit';
 
 interface SessionInfo {
     projectName: string;
@@ -167,16 +168,6 @@ interface TokenUsage {
     firstMessage: string;
     sessionCreated: Date | null;
     wasCleared: boolean;  // True if session ended with /clear command
-}
-
-// Determine context limit based on model
-function getContextLimitForModel(model: string, userLimit: number): number {
-    // Sonnet 4.5 1M has 1 million token context
-    if (model.toLowerCase().includes('sonnet') && model.toLowerCase().includes('1m')) {
-        return 1000000;
-    }
-    // All other models (Sonnet 4.5, Opus 4.5, Haiku) have 200K
-    return userLimit;
 }
 
 // Fuzzy emoji matching based on project name
@@ -416,6 +407,7 @@ async function findActiveSessions(): Promise<SessionInfo[]> {
 
     const config = vscode.workspace.getConfiguration('claudeContextBar');
     const contextLimit = config.get<number>('contextLimit', 200000);
+    const modelContextLimits = config.get<Record<string, number>>('modelContextLimits', {});
     const idleTimeout = config.get<number>('idleTimeout', 180);
 
     // Only look at sessions modified within the idle timeout (active sessions)
@@ -457,7 +449,7 @@ async function findActiveSessions(): Promise<SessionInfo[]> {
                     // Extract short session ID from filename
                     const sessionId = file.name.replace('.jsonl', '').substring(0, 8);
                     // Auto-detect context limit based on model
-                    const sessionContextLimit = getContextLimitForModel(usage.model, contextLimit);
+                    const sessionContextLimit = getContextLimitForModel(usage.model, contextLimit, modelContextLimits);
                     sessions.push({
                         projectName: name,
                         projectPath: fullPath,


### PR DESCRIPTION
## Summary

Rewrites context-limit detection so it sizes the window per model automatically, with no per-release maintenance. Originated in #3 by @JayYa (credited as co-author on the feature commit); reworked here.

## What it does

Resolves each session's context limit by priority:

☼ **Tier 1 user override** `claudeContextBar.modelContextLimits` (exact Model ID → token limit). Highest priority, no model is force-capped.
☼ **Tier 2 200K exceptions** Haiku (all versions) and legacy generations (Claude 3.x, Sonnet 4.5 and earlier, Opus 4.5 and earlier).
☼ **Tier 3 1M default** every other current Claude model (Opus 4.6+, Sonnet 4.6+, Sonnet 5, Fable 5, and anything newer).
☼ **Tier 4 fallback** unknown / non-Claude IDs use the `contextLimit` setting (default 200,000).

## Why default to 1M

Session JSONL records only the Model ID, no context-window field, and there is no local capability cache to read (Claude Code fetches it from the API at runtime). Every current frontier model ships at 1M by default, so defaulting to 1M means new models resolve correctly with zero code change. The maintenance burden flips from constant (add each new 1M model) to rare (a new 200K model), and the `haiku` pattern already covers that tier going forward.

## Changes vs #3

☼ Inverted the detection (1M default + denylist) instead of a sonnet-5-only allowlist, so it stays current automatically.
☼ Tests on Node's built-in `node:test` (25 tests), no vitest, zero new dependencies.
☼ Tightened `.vscodeignore` so the VSIX ships runtime files only (was leaking internal docs, graphify output, and dev scripts).
☼ Publisher ID kept as `ezoosk` (immutable marketplace identifier); GitHub account links updated to `edenaion` in a separate commit.

## Testing

☼ `npm test` 25/25 pass (tsc compile clean).
☼ Integration against real Model IDs from live sessions: Opus 4.8 and Fable 5 resolve to 1M, Haiku and Sonnet 4.5 to 200K.
☼ Packaged and installed the 1.5.0 VSIX locally; extension activates and reports correctly.

Credit to @JayYa (#3) for the original feature and design.