### PR TITLE
feat: add Claude subscription usage monitor to the status bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the Claude Context Bar extension will be documented in this file.
 
+## [1.6.0] - 2026-07-24
+
+### Added
+- **Subscription usage monitor** — shows your Claude `/usage` Session (5-hour) limit as a separate status bar item (e.g. `✴️ 7%`) to the right of the context items.
+  - Usage percentage has its own warning/danger colors, independent of the context colors, via `usageWarningThreshold` (default 50) and `usageDangerThreshold` (default 75).
+  - Hover tooltip shows all subscription limits — Session (5h), Weekly (all models), and any scoped weekly limits (e.g. Weekly Fable) — with reset times.
+  - Data comes from the authenticated `GET /api/oauth/usage` endpoint, using the OAuth token from the OS credential store (macOS Keychain or `~/.claude/.credentials.json`), exactly as Claude Code does. The token is only used as a request header and is never logged.
+  - Refreshes on its own cadence (`usageRefreshInterval`, default 60s), keeps the last known value on transient failures.
+  - Toggle with the `showUsage` setting (default on). Automatically hides when not signed in with a subscription (e.g. API-key auth).
+  - Note: `/api/oauth/usage` is an undocumented endpoint reverse-engineered from Claude Code; its response shape may change without notice. The parser is defensive (two schema paths, tolerant field reading) and degrades to hiding the item rather than erroring.
+- Unit tests for the usage response parser (`parseUsage`), covering the canonical `limits` array and the flat-meter fallback.
+
 ## [1.5.1] - 2026-07-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to the Claude Context Bar extension will be documented in th
 ## [1.6.0] - 2026-07-24
 
 ### Added
-- **Subscription usage monitor** — shows your Claude `/usage` Session (5-hour) limit as a separate status bar item (e.g. `✴️ 7%`) to the right of the context items.
+- **Subscription usage monitor** (opt-in, off by default) — shows your Claude `/usage` Session (5-hour) limit as a separate status bar item (e.g. `✴️ 7%`) to the right of the context items.
   - Usage percentage has its own warning/danger colors, independent of the context colors, via `usageWarningThreshold` (default 50) and `usageDangerThreshold` (default 75).
   - Hover tooltip shows all subscription limits — Session (5h), Weekly (all models), and any scoped weekly limits (e.g. Weekly Fable) — with reset times.
   - Data comes from the authenticated `GET /api/oauth/usage` endpoint, using the OAuth token from the OS credential store (macOS Keychain or `~/.claude/.credentials.json`), exactly as Claude Code does. The token is only used as a request header and is never logged.
   - Refreshes on its own cadence (`usageRefreshInterval`, default 60s), keeps the last known value on transient failures.
-  - Toggle with the `showUsage` setting (default on). Automatically hides when not signed in with a subscription (e.g. API-key auth).
-  - Note: `/api/oauth/usage` is an undocumented endpoint reverse-engineered from Claude Code; its response shape may change without notice. The parser is defensive (two schema paths, tolerant field reading) and degrades to hiding the item rather than erroring.
+  - Enable with the `showUsage` setting (default off). Automatically hides when not signed in with a subscription (e.g. API-key auth).
+  - Note: `/api/oauth/usage` is an undocumented endpoint reverse-engineered from Claude Code; treat this feature as a temporary bonus that may stop working at any time. The parser is defensive (two schema paths, tolerant field reading) and degrades to hiding the item rather than erroring.
 - Unit tests for the usage response parser (`parseUsage`), covering the canonical `limits` array and the flat-meter fallback.
 
 ## [1.5.1] - 2026-07-22

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 🧠 **Live Context Tracking** — See your Claude Code context usage percentage right in the status bar
 
+✴️ **Subscription Usage** — See your Claude `/usage` Session (5-hour) limit as its own status bar item (e.g. `✴️ 7%`), with color-coded warnings independent of the context colors. Hover for the full breakdown (Weekly, and per-model limits like Weekly Fable) with reset times
+
 ⚡ **Per-Tab Monitoring** — Each Claude Code tab gets its own context indicator
 
 🎯 **Fuzzy Emoji Matching** — Icons automatically match your project type based on name keywords:
@@ -61,6 +63,10 @@
 | `claudeContextBar.modelContextLimits` | `{}` | Per-model overrides: Model ID → token limit (e.g., `{"claude-haiku-4-5": 500000}`). Exact match, highest priority |
 | `claudeContextBar.warningThreshold` | `50` | Percentage for yellow warning |
 | `claudeContextBar.dangerThreshold` | `75` | Percentage for red danger |
+| `claudeContextBar.showUsage` | `true` | Show your Claude subscription usage (the 5-hour session limit from `/usage`) as a separate item |
+| `claudeContextBar.usageWarningThreshold` | `50` | Usage percentage for yellow warning (independent of context) |
+| `claudeContextBar.usageDangerThreshold` | `75` | Usage percentage for red danger (independent of context) |
+| `claudeContextBar.usageRefreshInterval` | `60` | How often (seconds) to refresh subscription usage from the `/usage` endpoint |
 | `claudeContextBar.refreshInterval` | `30` | Refresh interval in seconds |
 | `claudeContextBar.idleTimeout` | `180` | Seconds of inactivity before hiding a session (3 minutes). Set `0` to never hide idle sessions |
 | `claudeContextBar.compactMode` | `false` | Shorten project names to save status bar space |
@@ -78,6 +84,12 @@ The extension reads Claude Code's session files from `~/.claude/projects/` and c
 Claude session files record only the Model ID, with no context-window field, so the limit is inferred from the ID. The default is 1M because current frontier models all ship with a 1M window, which means new models resolve correctly with no update needed. Haiku and legacy models are the 200K exceptions. If any model is ever mis-sized (for example, your plan caps a model lower than its API window), pin an exact value in `modelContextLimits` and it always wins.
 
 Sessions inactive for more than 3 minutes (configurable via `idleTimeout`, `0` disables hiding) are automatically hidden, and reappear as soon as a resumed session writes new activity. The window regaining focus also triggers an immediate rescan. The extension also detects when sessions have been superseded by newer ones (e.g., after running `/clear` and opening a new tab), hiding ghost sessions immediately.
+
+### Subscription usage
+
+The context percentage is computed entirely from local files. The subscription usage (the `/usage` limits) is different: it is fetched from Claude's authenticated `GET /api/oauth/usage` endpoint, using the OAuth token that Claude Code stores in your OS credential store (macOS Keychain item `Claude Code-credentials`, or `~/.claude/.credentials.json` on Linux/Windows). This is the same data and the same mechanism Claude Code uses for its own `/usage` command; the token is used only as the request's `Authorization` header and is never logged or stored by the extension.
+
+Usage is refreshed on its own cadence (`usageRefreshInterval`, default 60 seconds, independent of the context refresh) and the last known value is kept during transient failures. The endpoint rate-limits frequent polling, so avoid setting the interval very low. If you are not signed in with a Claude subscription (for example, using an API key), the usage item simply doesn't appear. Turn it off entirely with `showUsage`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 🧠 **Live Context Tracking** — See your Claude Code context usage percentage right in the status bar
 
-✴️ **Subscription Usage** — See your Claude `/usage` Session (5-hour) limit as its own status bar item (e.g. `✴️ 7%`), with color-coded warnings independent of the context colors. Hover for the full breakdown (Weekly, and per-model limits like Weekly Fable) with reset times
+✴️ **Subscription Usage** — Opt-in (off by default): see your Claude `/usage` Session (5-hour) limit as its own status bar item (e.g. `✴️ 7%`), with color-coded warnings independent of the context colors. Hover for the full breakdown (Weekly, and per-model limits like Weekly Fable) with reset times. Experimental, may stop working at any time (see [Subscription usage](#subscription-usage))
 
 ⚡ **Per-Tab Monitoring** — Each Claude Code tab gets its own context indicator
 
@@ -63,7 +63,7 @@
 | `claudeContextBar.modelContextLimits` | `{}` | Per-model overrides: Model ID → token limit (e.g., `{"claude-haiku-4-5": 500000}`). Exact match, highest priority |
 | `claudeContextBar.warningThreshold` | `50` | Percentage for yellow warning |
 | `claudeContextBar.dangerThreshold` | `75` | Percentage for red danger |
-| `claudeContextBar.showUsage` | `true` | Show your Claude subscription usage (the 5-hour session limit from `/usage`) as a separate item |
+| `claudeContextBar.showUsage` | `false` | Opt-in: show your Claude subscription usage (the 5-hour session limit from `/usage`) as a separate item. Experimental, may stop working at any time |
 | `claudeContextBar.usageWarningThreshold` | `50` | Usage percentage for yellow warning (independent of context) |
 | `claudeContextBar.usageDangerThreshold` | `75` | Usage percentage for red danger (independent of context) |
 | `claudeContextBar.usageRefreshInterval` | `60` | How often (seconds) to refresh subscription usage from the `/usage` endpoint |
@@ -86,6 +86,8 @@ Claude session files record only the Model ID, with no context-window field, so 
 Sessions inactive for more than 3 minutes (configurable via `idleTimeout`, `0` disables hiding) are automatically hidden, and reappear as soon as a resumed session writes new activity. The window regaining focus also triggers an immediate rescan. The extension also detects when sessions have been superseded by newer ones (e.g., after running `/clear` and opening a new tab), hiding ghost sessions immediately.
 
 ### Subscription usage
+
+> **Experimental, off by default.** This feature relies on an undocumented Anthropic endpoint (the one Claude Code's own `/usage` command reads). Treat it as a temporary bonus: it may change or stop working at any time, entirely at Anthropic's discretion. Enable it with `claudeContextBar.showUsage: true`.
 
 The context percentage is computed entirely from local files. The subscription usage (the `/usage` limits) is different: it is fetched from Claude's authenticated `GET /api/oauth/usage` endpoint, using the OAuth token that Claude Code stores in your OS credential store (macOS Keychain item `Claude Code-credentials`, or `~/.claude/.credentials.json` on Linux/Windows). This is the same data and the same mechanism Claude Code uses for its own `/usage` command; the token is used only as the request's `Authorization` header and is never logged or stored by the extension.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
     "name": "claude-context-bar",
-    "version": "1.1.2",
+    "version": "1.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "claude-context-bar",
-            "version": "1.1.2",
+            "version": "1.6.0",
+            "license": "MIT",
             "devDependencies": {
                 "@types/node": "^18.0.0",
                 "@types/vscode": "^1.74.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "claude-context-bar",
     "displayName": "Claude Context Bar",
     "description": "Real-time context window usage monitor for Claude Code sessions. See token counts in your status bar with color-coded warnings.",
-    "version": "1.5.1",
+    "version": "1.6.0",
     "publisher": "ezoosk",
     "author": {
         "name": "Ed Zisk",
@@ -89,6 +89,26 @@
                     "type": "number",
                     "default": 75,
                     "description": "Percentage at which to show danger color (red)"
+                },
+                "claudeContextBar.showUsage": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show your Claude subscription usage (the 5-hour session limit from /usage) as a separate item to the right of the context items. Requires being signed in to Claude Code with a subscription."
+                },
+                "claudeContextBar.usageWarningThreshold": {
+                    "type": "number",
+                    "default": 50,
+                    "description": "Usage percentage at which to show warning color (yellow) on the usage item"
+                },
+                "claudeContextBar.usageDangerThreshold": {
+                    "type": "number",
+                    "default": 75,
+                    "description": "Usage percentage at which to show danger color (red) on the usage item"
+                },
+                "claudeContextBar.usageRefreshInterval": {
+                    "type": "number",
+                    "default": 60,
+                    "description": "How often (in seconds) to refresh subscription usage from the /usage endpoint. The endpoint rate-limits aggressive polling, so avoid very low values."
                 },
                 "claudeContextBar.refreshInterval": {
                     "type": "number",

--- a/package.json
+++ b/package.json
@@ -92,8 +92,8 @@
                 },
                 "claudeContextBar.showUsage": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Show your Claude subscription usage (the 5-hour session limit from /usage) as a separate item to the right of the context items. Requires being signed in to Claude Code with a subscription."
+                    "default": false,
+                    "description": "Show your Claude subscription usage (the 5-hour session limit from /usage) as a separate item to the right of the context items. Opt-in: reads the Claude Code OAuth token and calls an undocumented Anthropic endpoint, which may stop working at any time. Requires being signed in to Claude Code with a subscription."
                 },
                 "claudeContextBar.usageWarningThreshold": {
                     "type": "number",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as readline from 'readline';
 import { getContextLimitForModel } from './contextLimit';
+import { getUsage, UsageData, UsageMeter } from './usage';
 
 interface SessionInfo {
     projectName: string;
@@ -34,6 +35,15 @@ const hiddenSessions: Map<string, number> = new Map();
 let fileWatcher: fs.FSWatcher | null = null;
 let refreshInterval: NodeJS.Timeout | null = null;
 
+// Subscription usage shown in a single
+// status bar item to the right of the per-tab context items.
+let usageItem: vscode.StatusBarItem | null = null;
+let usageData: UsageData | null = null;
+let usageInterval: NodeJS.Timeout | null = null;
+
+const STATUS_BAR_PRIORITY_BASE = 900;
+const ITEM_CLAUDE_ICON = '✴️';
+
 export function activate(context: vscode.ExtensionContext) {
     console.log('Claude Context Bar is now active');
 
@@ -49,6 +59,7 @@ export function activate(context: vscode.ExtensionContext) {
     const configWatcher = vscode.workspace.onDidChangeConfiguration(e => {
         if (e.affectsConfiguration('claudeContextBar')) {
             refreshAllSessions();
+            refreshUsageData();
         }
     });
     context.subscriptions.push(configWatcher);
@@ -64,6 +75,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Initial scan
     refreshAllSessions();
+    refreshUsageData();
 
     // Set up file watcher
     const claudeProjectsDir = getClaudeProjectsDir();
@@ -83,6 +95,8 @@ export function activate(context: vscode.ExtensionContext) {
     const config = vscode.workspace.getConfiguration('claudeContextBar');
     const intervalSeconds = config.get<number>('refreshInterval', 30);
     refreshInterval = setInterval(refreshAllSessions, intervalSeconds * 1000);
+    const usageIntervalSeconds = config.get<number>('usageRefreshInterval', 60);
+    usageInterval = setInterval(refreshUsageData, usageIntervalSeconds * 1000);
 
     // Clean up on deactivation
     context.subscriptions.push({
@@ -93,8 +107,13 @@ export function activate(context: vscode.ExtensionContext) {
             if (refreshInterval) {
                 clearInterval(refreshInterval);
             }
+            if (usageInterval) {
+                clearInterval(usageInterval);
+            }
             statusBarItems.forEach(entry => entry.item.dispose());
             statusBarItems.clear();
+            usageItem?.dispose();
+            usageItem = null;
         }
     });
 }
@@ -106,8 +125,13 @@ export function deactivate() {
     if (refreshInterval) {
         clearInterval(refreshInterval);
     }
+    if (usageInterval) {
+        clearInterval(usageInterval);
+    }
     statusBarItems.forEach(entry => entry.item.dispose());
     statusBarItems.clear();
+    usageItem?.dispose();
+    usageItem = null;
 }
 
 function getClaudeProjectsDir(): string {
@@ -662,8 +686,9 @@ async function refreshAllSessions() {
 
         if (!entry) {
             // Create new status bar item - Right align, very high priority to appear LEFT of Claude's items
-            // Higher priority = further left on right-aligned items
-            const priority = 900 + (sessions.length - i); // Very high = leftmost in right section
+            // Higher priority = further left on right-aligned items. Context items stack
+            // above the usage item (STATUS_BAR_PRIORITY_BASE), so they sit to its left.
+            const priority = STATUS_BAR_PRIORITY_BASE + (sessions.length - i);
             const item = vscode.window.createStatusBarItem(
                 vscode.StatusBarAlignment.Right,
                 priority
@@ -723,4 +748,107 @@ async function refreshAllSessions() {
             statusBarItems.delete(sessionFile);
         }
     }
+
+    // Render the usage item to the right of the context items.
+    renderUsageItem();
+}
+
+// Render the single global usage item (e.g. "✴️ 7%") to the right of the context items.
+function renderUsageItem() {
+    const config = vscode.workspace.getConfiguration('claudeContextBar');
+    const showUsage = config.get<boolean>('showUsage', true);
+
+    if (!showUsage || !usageData?.session) {
+        usageItem?.dispose();
+        usageItem = null;
+        return;
+    }
+
+    const warningThreshold = config.get<number>('usageWarningThreshold', 50);
+    const dangerThreshold = config.get<number>('usageDangerThreshold', 75);
+
+    if (!usageItem) {
+        // Priority just below the context items (which start at 901) so this
+        // sits immediately to their right, still left of Claude Code's own items.
+        usageItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, STATUS_BAR_PRIORITY_BASE);
+    }
+
+    const session = usageData.session;
+    usageItem.text = `${ITEM_CLAUDE_ICON} ${session.percentage}%`;
+
+    if (session.percentage >= dangerThreshold) {
+        usageItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
+    } else if (session.percentage >= warningThreshold) {
+        usageItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
+    } else {
+        usageItem.backgroundColor = undefined;
+    }
+
+    usageItem.tooltip = buildUsageTooltip(usageData);
+    usageItem.show();
+}
+
+function formatReset(resetsAt: Date | null): string {
+    if (!resetsAt) {
+        return '';
+    }
+    const msLeft = resetsAt.getTime() - Date.now();
+    if (msLeft <= 0) {
+        return ' — resetting';
+    }
+    const hours = Math.floor(msLeft / 3_600_000);
+    const days = Math.floor(hours / 24);
+    const rel = days >= 1 ? `${days}d` : hours >= 1 ? `${hours}h` : `${Math.max(1, Math.round(msLeft / 60_000))}m`;
+    return ` — resets in ${rel}`;
+}
+
+function buildUsageTooltip(data: UsageData): vscode.MarkdownString {
+    const rows = data.meters
+        .map((m: UsageMeter) => `| ${m.label} | **${m.percentage}%** | ${formatReset(m.resetsAt).replace(/^ — /, '')} |`)
+        .join('\n');
+
+    return new vscode.MarkdownString(
+        `⚡ **Claude Usage**\n\n` +
+        `| Limit | Used | Resets |\n|------|------|------|\n` +
+        rows +
+        `\n\n*Subscription rate limits (\`/usage\`)*`
+    );
+}
+
+let usageFetchInFlight = false;
+
+// Version of the Claude Code extension running in this same IDE, used for the
+// usage request's User-Agent. This is the relevant client version (not any CLI on PATH).
+function getClaudeCodeVersion(): string | null {
+    return vscode.extensions.getExtension('anthropic.claude-code')?.packageJSON?.version ?? null;
+}
+
+async function refreshUsageData() {
+    const config = vscode.workspace.getConfiguration('claudeContextBar');
+    const showUsage = config.get<boolean>('showUsage', true);
+
+    if (!showUsage) {
+        usageData = null;
+        renderUsageItem();
+        return;
+    }
+
+    // The usage endpoint rate-limits aggressive polling; never overlap calls.
+    if (usageFetchInFlight) {
+        return;
+    }
+    usageFetchInFlight = true;
+    try {
+        const fetched = await getUsage(getClaudeCodeVersion());
+        // Keep the last successful value on a transient failure rather than flicker.
+        if (fetched) {
+            usageData = fetched;
+        }
+    } catch (e) {
+        console.error('Failed to fetch Claude usage:', e);
+    } finally {
+        usageFetchInFlight = false;
+    }
+
+    renderUsageItem();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -756,7 +756,7 @@ async function refreshAllSessions() {
 // Render the single global usage item (e.g. "✴️ 7%") to the right of the context items.
 function renderUsageItem() {
     const config = vscode.workspace.getConfiguration('claudeContextBar');
-    const showUsage = config.get<boolean>('showUsage', true);
+    const showUsage = config.get<boolean>('showUsage', false);
 
     if (!showUsage || !usageData?.session) {
         usageItem?.dispose();
@@ -825,7 +825,7 @@ function getClaudeCodeVersion(): string | null {
 
 async function refreshUsageData() {
     const config = vscode.workspace.getConfiguration('claudeContextBar');
-    const showUsage = config.get<boolean>('showUsage', true);
+    const showUsage = config.get<boolean>('showUsage', false);
 
     if (!showUsage) {
         usageData = null;

--- a/src/usage.test.ts
+++ b/src/usage.test.ts
@@ -1,0 +1,118 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseUsage } from './usage';
+
+// A response shaped like the real GET /api/oauth/usage body, trimmed to the
+// fields the parser reads.
+function realBody() {
+    return {
+        five_hour: { utilization: 30.0, resets_at: '2026-07-12T18:50:00.02+00:00' },
+        seven_day: { utilization: 16.0, resets_at: '2026-07-14T00:00:00.02+00:00' },
+        seven_day_opus: null,
+        limits: [
+            { kind: 'session', group: 'session', percent: 30, resets_at: '2026-07-12T18:50:00.02+00:00', scope: null, is_active: true },
+            { kind: 'weekly_all', group: 'weekly', percent: 16, resets_at: '2026-07-14T00:00:00.02+00:00', scope: null, is_active: false },
+            { kind: 'weekly_scoped', group: 'weekly', percent: 0, resets_at: null, scope: { model: { id: null, display_name: 'Fable' } }, is_active: false },
+        ],
+        member_dashboard_available: false,
+    };
+}
+
+describe('parseUsage — limits array (real response)', () => {
+    it('returns null for empty / non-object / no-limits bodies', () => {
+        assert.equal(parseUsage(null), null);
+        assert.equal(parseUsage({}), null);
+        assert.equal(parseUsage({ member_dashboard_available: false }), null);
+    });
+
+    it('maps the three limits to labeled meters in order', () => {
+        const data = parseUsage(realBody());
+        assert.ok(data);
+        assert.deepEqual(
+            data!.meters.map((m) => m.label),
+            ['Session (5h)', 'Weekly (all models)', 'Weekly Fable'],
+        );
+        assert.deepEqual(data!.meters.map((m) => m.percentage), [30, 16, 0]);
+    });
+
+    it('identifies the session meter for the status bar', () => {
+        const data = parseUsage(realBody());
+        assert.equal(data!.session!.label, 'Session (5h)');
+        assert.equal(data!.session!.percentage, 30);
+        assert.equal(data!.session!.isActive, true);
+    });
+
+    it('parses ISO reset timestamps and tolerates null', () => {
+        const data = parseUsage(realBody());
+        assert.ok(data!.meters[0].resetsAt instanceof Date);
+        assert.equal(data!.meters[2].resetsAt, null);
+    });
+
+    it('derives scoped weekly labels from the model display name', () => {
+        const body = {
+            limits: [
+                { kind: 'session', percent: 5, is_active: true },
+                { kind: 'weekly_scoped', percent: 2, scope: { model: { display_name: 'Opus' } } },
+            ],
+        };
+        const data = parseUsage(body);
+        assert.equal(data!.meters[1].label, 'Weekly Opus');
+        // Scoped meters get distinct keys so multiple models don't collide.
+        assert.equal(data!.meters[1].key, 'weekly_scoped:Opus');
+    });
+
+    it('humanizes an unknown limit kind', () => {
+        const data = parseUsage({ limits: [{ kind: 'monthly_special', percent: 3 }] });
+        assert.equal(data!.meters[0].label, 'Monthly Special');
+    });
+
+    it('skips limits without a usable percent', () => {
+        const data = parseUsage({
+            limits: [
+                { kind: 'session', percent: 30, is_active: true },
+                { kind: 'weekly_all' },
+            ],
+        });
+        assert.deepEqual(data!.meters.map((m) => m.label), ['Session (5h)']);
+    });
+
+    it('clamps and rounds percentages', () => {
+        const data = parseUsage({ limits: [{ kind: 'session', percent: 28.6 }, { kind: 'weekly_all', percent: 140 }] });
+        assert.equal(data!.meters[0].percentage, 29);
+        assert.equal(data!.meters[1].percentage, 100);
+    });
+});
+
+describe('parseUsage — fallback (no limits array)', () => {
+    it('reads flat top-level windows when limits is absent', () => {
+        const data = parseUsage({
+            five_hour: { utilization: 7, resets_at: 1_800_000_000 },
+            seven_day: { utilization: 14 },
+            member_dashboard_available: false,
+        });
+        assert.equal(data!.session!.label, 'Session (5h)');
+        assert.equal(data!.session!.percentage, 7);
+        assert.deepEqual(data!.meters.map((m) => m.key), ['five_hour', 'seven_day']);
+    });
+
+    it('accepts a rate_limits wrapper and Unix-epoch resets', () => {
+        const epoch = 1_800_000_000;
+        const data = parseUsage({ rate_limits: { five_hour: { utilization: 10, resets_at: epoch } } });
+        assert.equal(data!.session!.resetsAt!.getTime(), epoch * 1000);
+    });
+
+    it('ignores non-window keys and null meters', () => {
+        const data = parseUsage({
+            five_hour: { utilization: 7 },
+            seven_day_opus: null,
+            extra_usage: { utilization: 13.9 },
+            spend: { used: {} },
+        });
+        assert.deepEqual(data!.meters.map((m) => m.key), ['five_hour']);
+    });
+
+    it('falls back to used_percentage', () => {
+        const data = parseUsage({ five_hour: { used_percentage: 42 } });
+        assert.equal(data!.session!.percentage, 42);
+    });
+});

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,0 +1,339 @@
+/**
+ * Claude subscription usage ("/usage") — the 5-hour session and weekly rate
+ * limits shown by Claude Code's `/usage` command.
+ *
+ * Unlike context usage (computed from local JSONL files), this data lives only
+ * behind an authenticated Anthropic endpoint. We replicate exactly what Claude
+ * Code itself does on the user's machine:
+ *
+ *   1. Read the OAuth access token from the OS credential store
+ *      (macOS Keychain item "Claude Code-credentials", or ~/.claude/.credentials.json).
+ *   2. GET https://api.anthropic.com/api/oauth/usage with that Bearer token.
+ *   3. Read `rate_limits.<window>` meters ({ utilization, resets_at }).
+ *
+ * The token is only ever used as a request header and is never logged.
+ *
+ * CAVEAT: /api/oauth/usage is undocumented — its structure was reverse-engineered
+ * from the Claude Code binary and verified against live responses, so it may
+ * change without notice. Parsing is intentionally defensive (two schema paths,
+ * tolerant field reading) and degrades to null rather than throwing.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import * as https from 'https';
+import * as crypto from 'crypto';
+import { execFile } from 'child_process';
+
+export interface UsageMeter {
+    key: string;
+    label: string;
+    percentage: number;
+    resetsAt: Date | null;
+    /** Whether this is the limit currently binding the account. */
+    isActive: boolean;
+}
+
+export interface UsageData {
+    /** The 5-hour session meter, shown in the status bar. Null if absent. */
+    session: UsageMeter | null;
+    /** Every meter present, for the tooltip (session first, then weekly ones). */
+    meters: UsageMeter[];
+}
+
+/**
+ * Labels for the `limits[].kind` values that aren't derived from a model scope.
+ * `session` and `weekly_all` are handled explicitly; scoped windows (Opus,
+ * Sonnet, Fable) use their server-supplied model display name.
+ */
+const LIMIT_KIND_LABELS: Record<string, string> = {
+    session: 'Session (5h)',
+    weekly_all: 'Weekly (all models)',
+    weekly_opus: 'Weekly (Opus)',
+    weekly_sonnet: 'Weekly (Sonnet)',
+};
+
+/**
+ * Labels for the flat top-level meter keys, used only on the fallback path when
+ * the response has no `limits` array.
+ */
+const METER_LABELS: Record<string, string> = {
+    five_hour: 'Session (5h)',
+    seven_day: 'Weekly (all models)',
+    seven_day_opus: 'Weekly (Opus)',
+    seven_day_sonnet: 'Weekly (Sonnet)',
+    seven_day_oauth_apps: 'Weekly (apps)',
+};
+
+function humanizeKey(key: string): string {
+    return key
+        .split(/[_\s]+/)
+        .map((w) => (w.length ? w[0].toUpperCase() + w.slice(1) : w))
+        .join(' ');
+}
+
+/**
+ * The macOS Keychain service name Claude Code stores its credentials under.
+ * Mirrors Claude Code's own derivation: "Claude Code-credentials", with an
+ * 8-char config-dir hash suffix appended when a non-default CLAUDE_CONFIG_DIR
+ * (or CLAUDE_SECURESTORAGE_CONFIG_DIR) is in use.
+ */
+function keychainServiceName(): string {
+    const secureDir = process.env.CLAUDE_SECURESTORAGE_CONFIG_DIR;
+    const configDir = process.env.CLAUDE_CONFIG_DIR;
+
+    const isDefault = secureDir !== undefined ? !secureDir : !configDir;
+    if (isDefault) {
+        return 'Claude Code-credentials';
+    }
+
+    const dir = (secureDir !== undefined ? secureDir : configDir || '').normalize('NFC');
+    const hash = crypto.createHash('sha256').update(dir).digest('hex').substring(0, 8);
+    return `Claude Code-credentials-${hash}`;
+}
+
+function keychainAccount(): string {
+    try {
+        return process.env.USER || os.userInfo().username;
+    } catch {
+        return 'claude-code-user';
+    }
+}
+
+function extractAccessToken(raw: string): string | null {
+    try {
+        const parsed = JSON.parse(raw);
+        const token = parsed?.claudeAiOauth?.accessToken;
+        return typeof token === 'string' && token.length > 0 ? token : null;
+    } catch {
+        return null;
+    }
+}
+
+function readTokenFromCredentialsFile(): string | null {
+    const configDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
+    const file = path.join(configDir, '.credentials.json');
+    try {
+        if (!fs.existsSync(file)) {
+            return null;
+        }
+        return extractAccessToken(fs.readFileSync(file, 'utf-8'));
+    } catch {
+        return null;
+    }
+}
+
+function readTokenFromKeychain(): Promise<string | null> {
+    return new Promise((resolve) => {
+        execFile(
+            'security',
+            ['find-generic-password', '-a', keychainAccount(), '-w', '-s', keychainServiceName()],
+            { timeout: 5000 },
+            (err, stdout) => {
+                if (err || !stdout) {
+                    resolve(null);
+                    return;
+                }
+                resolve(extractAccessToken(stdout.trim()));
+            },
+        );
+    });
+}
+
+/**
+ * Read the Claude Code OAuth access token from the OS credential store.
+ * Returns null if unavailable (not logged in, API-key auth, etc.).
+ */
+export async function readOAuthToken(): Promise<string | null> {
+    if (process.platform === 'darwin') {
+        const fromKeychain = await readTokenFromKeychain();
+        if (fromKeychain) {
+            return fromKeychain;
+        }
+    }
+    // Linux/Windows store a plaintext file; also a fallback on macOS.
+    return readTokenFromCredentialsFile();
+}
+
+/** Pull a 0-100 percentage out of a meter object, tolerating schema variants. */
+function readPercentage(meter: any): number | null {
+    if (!meter || typeof meter !== 'object') {
+        return null;
+    }
+    // `percent` (limits array) → `utilization` (flat meters) → `used_percentage`.
+    let value = meter.percent;
+    if (typeof value !== 'number') {
+        value = meter.utilization;
+    }
+    if (typeof value !== 'number') {
+        value = meter.used_percentage;
+    }
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+        return null;
+    }
+    // The endpoint reports these already as 0-100 percentages.
+    return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+/** Parse a reset time given as an ISO string or Unix epoch seconds. */
+function readResetsAt(meter: any): Date | null {
+    const value = meter?.resets_at;
+    if (typeof value === 'number') {
+        return new Date(value * 1000);
+    }
+    if (typeof value === 'string' && value) {
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? null : date;
+    }
+    return null;
+}
+
+function labelForLimit(entry: any): string {
+    const kind = String(entry?.kind ?? '');
+    if (kind === 'session' || kind === 'weekly_all') {
+        return LIMIT_KIND_LABELS[kind];
+    }
+    const scopedName = entry?.scope?.model?.display_name;
+    if (typeof scopedName === 'string' && scopedName) {
+        return `Weekly ${scopedName}`;
+    }
+    return LIMIT_KIND_LABELS[kind] || humanizeKey(kind || 'limit');
+}
+
+/**
+ * Parse the canonical `limits` array (what the /usage UI renders). Each entry
+ * is `{ kind, group, percent, severity, resets_at, scope, is_active }`.
+ */
+function parseFromLimits(limits: any[]): UsageData | null {
+    const meters: UsageMeter[] = [];
+    let session: UsageMeter | null = null;
+
+    for (const entry of limits) {
+        const percentage = readPercentage(entry);
+        if (percentage === null) {
+            continue;
+        }
+        const label = labelForLimit(entry);
+        // Distinct key per scoped model so multiple weekly buckets don't collide.
+        const scopedName = entry?.scope?.model?.display_name;
+        const key = scopedName ? `${entry?.kind}:${scopedName}` : String(entry?.kind ?? label);
+        const meter: UsageMeter = {
+            key,
+            label,
+            percentage,
+            resetsAt: readResetsAt(entry),
+            isActive: entry?.is_active === true,
+        };
+        meters.push(meter);
+        if (entry?.kind === 'session' && !session) {
+            session = meter;
+        }
+    }
+
+    return meters.length ? { session, meters } : null;
+}
+
+/**
+ * Fallback parser for responses without a `limits` array: read the flat
+ * top-level windows (`five_hour`, `seven_day`, `seven_day_*`).
+ */
+function parseFromKeyedMeters(source: Record<string, any>): UsageData | null {
+    const meters: UsageMeter[] = [];
+
+    for (const [key, raw] of Object.entries(source)) {
+        if (key !== 'five_hour' && !key.startsWith('seven_day')) {
+            continue;
+        }
+        const percentage = readPercentage(raw);
+        if (percentage === null) {
+            continue;
+        }
+        meters.push({
+            key,
+            label: METER_LABELS[key] || humanizeKey(key),
+            percentage,
+            resetsAt: readResetsAt(raw),
+            isActive: false,
+        });
+    }
+
+    if (!meters.length) {
+        return null;
+    }
+
+    meters.sort((a, b) => (a.key === 'five_hour' ? -1 : b.key === 'five_hour' ? 1 : 0));
+    return { session: meters.find((m) => m.key === 'five_hour') || null, meters };
+}
+
+/**
+ * Pure parser for the /api/oauth/usage response body. Exposed for testing.
+ * Returns null when there are no subscription rate limits (e.g. API-key auth).
+ */
+export function parseUsage(body: any): UsageData | null {
+    if (!body || typeof body !== 'object') {
+        return null;
+    }
+    // Preferred: the self-describing `limits` array (mirrors the /usage UI).
+    if (Array.isArray(body.limits) && body.limits.length > 0) {
+        return parseFromLimits(body.limits);
+    }
+    // Fallback: flat top-level windows, or a `rate_limits` wrapper.
+    const source = body.rate_limits && typeof body.rate_limits === 'object' ? body.rate_limits : body;
+    return parseFromKeyedMeters(source);
+}
+
+/**
+ * Fetch and parse the usage endpoint. Returns null on any failure.
+ * `claudeCodeVersion` is the installed Claude Code version (from the IDE
+ * extension) used for the User-Agent; falls back to a version-less UA.
+ */
+export function fetchUsage(token: string, claudeCodeVersion?: string | null): Promise<UsageData | null> {
+    const userAgent = claudeCodeVersion ? `claude-code/${claudeCodeVersion}` : 'claude-code';
+    return new Promise((resolve) => {
+        const req = https.request(
+            {
+                hostname: 'api.anthropic.com',
+                path: '/api/oauth/usage',
+                method: 'GET',
+                headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-Type': 'application/json',
+                    // Identifying as the Claude Code client is required to hit
+                    // less aggressive rate limiting on this endpoint.
+                    'User-Agent': userAgent,
+                },
+                timeout: 5000,
+            },
+            (res) => {
+                let data = '';
+                res.on('data', (chunk) => (data += chunk));
+                res.on('end', () => {
+                    if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
+                        resolve(null);
+                        return;
+                    }
+                    try {
+                        resolve(parseUsage(JSON.parse(data)));
+                    } catch {
+                        resolve(null);
+                    }
+                });
+            },
+        );
+        req.on('error', () => resolve(null));
+        req.on('timeout', () => {
+            req.destroy();
+            resolve(null);
+        });
+        req.end();
+    });
+}
+
+/** Read the token and fetch usage in one step. Returns null on any failure. */
+export async function getUsage(claudeCodeVersion?: string | null): Promise<UsageData | null> {
+    const token = await readOAuthToken();
+    if (!token) {
+        return null;
+    }
+    return fetchUsage(token, claudeCodeVersion);
+}


### PR DESCRIPTION
## Summary

Adds a subscription usage monitor alongside the existing per-tab context indicators.

- Shows the `/usage` **5-hour session limit** as its own status bar item (`✴️ N%`) to the right of the context items.
- Its warning/danger colors are **independent** of the context colors (`usageWarningThreshold` / `usageDangerThreshold`).
- Hover tooltip lists **all** subscription limits — Session (5h), Weekly (all models), and per-model scoped limits (e.g. Weekly Fable) — with reset times.

## How it works

Usage is fetched from the authenticated `GET /api/oauth/usage` endpoint using the OAuth token from the OS credential store (macOS Keychain item `Claude Code-credentials`, or `~/.claude/.credentials.json`). The token is only used as the `Authorization` header and is never logged. It refreshes on its own cadence (`usageRefreshInterval`, default 30s), keeps the last known value on transient failures, and hides when not signed in with a subscription (e.g. API-key auth).

> Note: `/api/oauth/usage` is undocumented (reverse-engineered from Claude Code), so its shape may change. The parser is defensive (canonical `limits` array + flat-meter fallback) and degrades to hiding the item rather than erroring.

## Changes

- New module `src/usage.ts` — token read + fetch + defensive parser, with unit tests (`src/usage.test.ts`).
- New settings: `showUsage`, `usageWarningThreshold`, `usageDangerThreshold`, `usageRefreshInterval`.
- Version bump to 1.6.0; README + CHANGELOG updated.

<img width="252" height="42" alt="image" src="https://github.com/user-attachments/assets/3f34e83f-ce35-4422-a333-aa41c96fd0dd" />

<img width="200" height="163" alt="image" src="https://github.com/user-attachments/assets/12b7ea5b-17f8-4268-a348-a320b1823f7c" />

